### PR TITLE
Tweak the version numbering so we can use it with later versions of React.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/jeroencoumans/react-scroll-components",
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": ">=0.12.0"
   },
   "dependencies": {},
   "devDependencies": {
-    "react-tools": "^0.12.0"
+    "react-tools": "~0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/jeroencoumans/react-scroll-components",
   "peerDependencies": {
-    "react": "~0.12.0"
+    "react": "^0.12.0"
   },
   "dependencies": {},
   "devDependencies": {
-    "react-tools": "~0.12.0"
+    "react-tools": "^0.12.0"
   }
 }


### PR DESCRIPTION
`ScrollListenerMixin` seems to work without issue on React 0.13.