### PR TITLE
@jsx pragma deprecated in 0.12

### DIFF
--- a/jsx/ScrollBlocker.jsx
+++ b/jsx/ScrollBlocker.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var assign = require('react/lib/Object.assign');
 


### PR DESCRIPTION
As found in: 

https://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html#the-jsx-pragma-is-gone

the React.DOM pragma has been deprecated as of React 0.12.
