### PR TITLE
Don't break IE8 by assuming add/removeEventListener.

### DIFF
--- a/ScrollListenerMixin.js
+++ b/ScrollListenerMixin.js
@@ -20,13 +20,21 @@ var ScrollListenerMixin = {
 
   componentDidMount: function () {
     if (win) {
-      win.addEventListener('scroll', this._onPageScroll);
+      if (win.addEventListener) {
+        win.addEventListener('scroll', this._onPageScroll);
+      } else if (win.attachEvent) {
+        win.attachEvent('onscroll', this._onPageScroll);
+      }
     }
   },
 
   componentWillUnmount: function () {
     if (win) {
-      win.removeEventListener('scroll', this._onPageScroll);
+      if (win.removeEventListener) {
+        win.removeEventListener('scroll', this._onPageScroll);
+      } else if (win.detachEvent) {
+        win.detachEvent('onscroll', this._onPageScroll);
+      }
     }
   },
 


### PR DESCRIPTION
Added add/detachEvent calls as alternative to add/removeEventListener, to prevent errors in IE8.

Since React officially supports IE8 and [addEventListener polyfills have a tendency to break event handling](https://github.com/facebook/react/issues/3131#issuecomment-128732009) in React, it's nice when components support IE8 out of the box.
